### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,15 @@ pip2amch
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/pip2amch
 
-.. |wheel| image:: https://pypip.in/wheel/pip2amch/badge.png?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/pip2amch.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/pip2amch
 
-.. |supported-versions| image:: https://pypip.in/py_versions/pip2amch/badge.png?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/pip2amch.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/pip2amch
 
-.. |supported-implementations| image:: https://pypip.in/implementation/pip2amch/badge.png?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/pip2amch.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/pip2amch
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pip2amch))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pip2amch`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.